### PR TITLE
Small enhancemente jamshidian engine

### DIFF
--- a/QuantLib/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
+++ b/QuantLib/ql/pricingengines/swaption/jamshidianswaptionengine.cpp
@@ -35,10 +35,11 @@ namespace QuantLib {
 
         Real operator()(Rate x) const {
             Real value = strike_;
+            Real discountBondMaturity = model_->discountBond(maturity_, valueTime_, x);
             Size size = times_.size();
             for (Size i=0; i<size; i++) {
                 Real dbValue =
-                    model_->discountBond(maturity_, times_[i], x) / model_->discountBond(maturity_, valueTime_, x);
+                    model_->discountBond(maturity_, times_[i], x) / discountBondMaturity;
                 value -= amounts_[i]*dbValue;
             }
             return value;
@@ -102,13 +103,14 @@ namespace QuantLib {
         Size size = arguments_.fixedCoupons.size();
 
         Real value = 0.0;
+        Real discountBondMaturity = model_->discountBond(maturity, valueTime, rStar);
         for (Size i=0; i<size; i++) {
             Real fixedPayTime =
                 dayCounter.yearFraction(referenceDate,
                                         arguments_.fixedPayDates[i]);
             Real strike = model_->discountBond(maturity,
                                                fixedPayTime,
-                                               rStar) / model_->discountBond(maturity,valueTime,rStar);
+                                               rStar) / discountBondMaturity;
             Real dboValue = model_->discountBondOption(
                                                w, strike, maturity, valueTime,
                                                fixedPayTime);


### PR DESCRIPTION
In the swaption jamshidian engine, in a recent implementation by Peter Caspers, there is a discountBond that is evaluated many times inside a loop, but does not depend on the index i.
It could be evaluated only once.

(open point wich variable name to choose, I proposed "discountBondMaturity", but "discountBond" or "endDiscount" could be more appropriate?)